### PR TITLE
Fix GCC build: add missing unistd.h for usleep()

### DIFF
--- a/threadpool.c
+++ b/threadpool.c
@@ -25,7 +25,9 @@ SOFTWARE.
 #include <stdint.h>
 #include <stdio.h>
 #include "threadpool.h"
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 
 #if defined(WIN32) || defined(_WIN64)
@@ -526,5 +528,6 @@ void tpool_add_work_fcn(tpool_t *tdata, void *work_fcn)
 
     return;
 }
+
 
 

--- a/threadpool.c
+++ b/threadpool.c
@@ -25,6 +25,7 @@ SOFTWARE.
 #include <stdint.h>
 #include <stdio.h>
 #include "threadpool.h"
+#include <unistd.h>
 
 
 #if defined(WIN32) || defined(_WIN64)
@@ -525,4 +526,5 @@ void tpool_add_work_fcn(tpool_t *tdata, void *work_fcn)
 
     return;
 }
+
 


### PR DESCRIPTION
`usleep()` requires `<unistd.h>` on POSIX systems.

Fixes implicit declaration error with GCC 11+.